### PR TITLE
fix logging on exception handling

### DIFF
--- a/source/elb_hostname_as_target.py
+++ b/source/elb_hostname_as_target.py
@@ -188,7 +188,6 @@ def lambda_handler(event, context):
 
     # Exception handler
     except Exception as e:
-        logger.error("ERROR:", e)
-        logger.error("ERROR: Invocation failed.")
+        logger.exception("ERROR: Invocation failed.")
         return(1)
     return (0)


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The previous behavior calls the logger incorrectly when handling an exception, throwing a new typeerror unrelated to the original. This fixes the issue.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
